### PR TITLE
:bug: fix shuffle, seek, jump, and back commands

### DIFF
--- a/commands/back.js
+++ b/commands/back.js
@@ -16,11 +16,11 @@ module.exports = class extends SlashCommand {
 
         await ctx.defer();
 
-        const queue = client.player.getQueue(interaction.guildId);
-        if (!queue || !queue.playing) return void interaction.sendFollowUp({ content: "❌ | No music is being played!" });
+        const queue = client.player.getQueue(ctx.guildID);
+        if (!queue || !queue.playing) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
         
         await queue.back();
 
-        interaction.sendFollowUp({ content: "✅ | Playing the previous track!" });
+        ctx.sendFollowUp({ content: "✅ | Playing the previous track!" });
     }
 }

--- a/commands/jump.js
+++ b/commands/jump.js
@@ -23,12 +23,12 @@ module.exports = class extends SlashCommand {
 
         await ctx.defer();
 
-        const queue = client.player.getQueue(interaction.guildId);
-        if (!queue || !queue.playing) return void interaction.sendFollowUp({ content: "❌ | No music is being played!" });
+        const queue = client.player.getQueue(ctx.guildID);
+        if (!queue || !queue.playing) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
         
         const tracksCount = ctx.options.tracks;
         queue.jump(tracksCount);
 
-        interaction.sendFollowUp({ content: `⏭ | Skipped ${tracksCount} tracks` });
+        ctx.sendFollowUp({ content: `⏭ | Skipped ${tracksCount} tracks` });
     }
 }

--- a/commands/seek.js
+++ b/commands/seek.js
@@ -23,12 +23,12 @@ module.exports = class extends SlashCommand {
 
         await ctx.defer();
 
-        const queue = client.player.getQueue(interaction.guildId);
-        if (!queue || !queue.playing) return void interaction.sendFollowUp({ content: "❌ | No music is being played!" });
+        const queue = client.player.getQueue(ctx.guildID);
+        if (!queue || !queue.playing) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
         
         const time = ctx.options.time * 1000;
         await queue.seek(time);
 
-        interaction.sendFollowUp({ content: `✅ | Seeked to ${time / 1000} seconds` });
+        ctx.sendFollowUp({ content: `✅ | Seeked to ${time / 1000} seconds` });
     }
 }

--- a/commands/shuffle.js
+++ b/commands/shuffle.js
@@ -16,11 +16,11 @@ module.exports = class extends SlashCommand {
 
         await ctx.defer();
 
-        const queue = client.player.getQueue(interaction.guildId);
-        if (!queue || !queue.playing) return void interaction.sendFollowUp({ content: "❌ | No music is being played!" });
+        const queue = client.player.getQueue(ctx.guildID);
+        if (!queue || !queue.playing) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
         
         await queue.shuffle();
         
-        interaction.sendFollowUp({ content: "✅ | Queue has been shuffled!" });
+        ctx.sendFollowUp({ content: "✅ | Queue has been shuffled!" });
     }
 }


### PR DESCRIPTION
Corrects the calls in the following commands (shuffle, seek, jump, and back) to use `ctx` instead of `interaction`, as well as the correct `guildID`, referenced from #11 