### PR TITLE
:sparkles: Enhanced functionality and fixed existing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Here are all the available commands in the bot!
 |:---------------|:-----------------------------------:|----------:|
 |   **/back**    |      Plays the previous track       |           |
 | **/bassboost** |      Toggles bassboost filter       |           |
+|   **/clear**   |      Clear the current queue.       |           |
 |   **/jump**    |      Jumps to a specific track      | \<tracks> |
 |   **/loop**    |           Sets loop mode            |  \<mode>  |
 |    **/np**     |  See what's currently being played  |           |
 |   **/pause**   |       Pause the current song        |           |
 |   **/play**    |      Plays a song from youtube      | \<query>  |
 | **/playnext**  | Adds a song to the top of the queue | \<query>  |
-|   **/queue**   |            See the queue            |           |
+|   **/queue**   |            See the queue            |  \<page>  |
+|  **/remove**   |       Remove a specific track       | \<track>  |
 |  **/resume**   |       Resume the current song       |           |
 |   **/seek**    |       Seeks to the given time       |  \<time>  |
 |  **/shuffle**  |         Shuffles the queue          |           |

--- a/commands/clear.js
+++ b/commands/clear.js
@@ -1,0 +1,26 @@
+const { SlashCommand, CommandOptionType } = require('slash-create');
+
+module.exports = class extends SlashCommand {
+    constructor(creator) {
+        super(creator, {
+            name: "clear",
+            description: "Clear the current queue.",
+            
+            guildIDs: process.env.DISCORD_GUILD_ID ? [ process.env.DISCORD_GUILD_ID ] : undefined
+        });
+    }
+
+    async run (ctx) {
+
+        const { client } = require('..');
+
+        await ctx.defer();
+
+        const queue = client.player.getQueue(ctx.guildID);
+        if (!queue) return void ctx.sendFollowUp({ content: "❌ | No music in the queue!" });
+        
+        queue.clear();
+
+        ctx.sendFollowUp({ content: `❌ | Queue cleared.` });
+    }
+}

--- a/commands/playnext.js
+++ b/commands/playnext.js
@@ -40,6 +40,6 @@ module.exports = class extends SlashCommand {
 
         if (!searchResult || !searchResult.tracks.length) return void ctx.sendFollowUp({ content: "No results were found!" });
         queue.insert(searchResult.tracks[0]); 
-
+	await ctx.sendFollowUp({ content: `⏱ | Loading your track...` });
     }
 }

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -3,13 +3,14 @@ const { SlashCommand, CommandOptionType } = require('slash-create');
 module.exports = class extends SlashCommand {
     constructor(creator) {
         super(creator, {
-            name: "jump",
-            description: "Jumps to a specific track",
+            name: "remove",
+            description: "Remove a specific track",
             options: [
                 {
-                    name: "tracks",
-                    description: "The number of tracks to skip",
-                    type: CommandOptionType.INTEGER
+                    name: "track",
+                    description: "The number of the track to remove",
+                    type: CommandOptionType.INTEGER,
+                    required: true
                 }
             ],
             
@@ -24,12 +25,12 @@ module.exports = class extends SlashCommand {
         await ctx.defer();
 
         const queue = client.player.getQueue(ctx.guildID);
-        if (!queue || !queue.playing) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
+        if (!queue) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
         
-        const trackIndex = ctx.options.tracks - 1;
+        const trackIndex = ctx.options.track - 1;
         const trackName = queue.tracks[trackIndex].title;
-        queue.jump(trackIndex);
+        queue.remove(trackIndex);
 
-        ctx.sendFollowUp({ content: `⏭ | **${trackName}** has jumped the queue!` });
+        ctx.sendFollowUp({ content: `❌ | Removed track ${trackName}.` });
     }
 }

--- a/commands/resume.js
+++ b/commands/resume.js
@@ -19,6 +19,6 @@ module.exports = class extends SlashCommand {
         const queue = client.player.getQueue(ctx.guildID);
         if (!queue || !queue.playing) return void ctx.sendFollowUp({ content: "❌ | No music is being played!" });
         const paused = queue.setPaused(false);
-        return void ctx.sendFollowUp({ content: !paused ? "▶ | Resumed!" : "❌ | Something went wrong!" });
+        return void ctx.sendFollowUp({ content: paused ? "▶ | Resumed!" : "❌ | Something went wrong!" });
     }
 }


### PR DESCRIPTION
Fixed: Jump using 0 as the starting index for jumps. Now should jump to the matching number from the queue
Fixed: Resume returning "Something went wrong" when succeeding
Fixed: Playnext having the bot get stuck "thinking" when succeeding
Enhanced: Queue to now be able to take page numbers, allowing you to view entire queue
Added: Clear command to clear the queue
Added: Remove command to remove a song from the queue