### PR TITLE
Add opusscript as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "discord-player": "^5.1.0",
     "discord.js": "^13.1.0",
     "dotenv": "^10.0.0",
+    "opusscript": "^0.0.8",
     "slash-create": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
After installing opusscript as a dependency as mentioned on https://github.com/Androz2091/discord-music-bot/issues/26, the bot was able to work on my machine. I've added on this PR this missing dependency. 