### PR TITLE
Sync permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,15 @@ creator
     )
     .registerCommandsIn(path.join(__dirname, 'commands'));
 
-if (process.env.DISCORD_GUILD_ID) creator.syncCommandsIn(process.env.DISCORD_GUILD_ID);
-else creator.syncCommands();
+
+if (process.env.DISCORD_GUILD_ID) {
+    creator.syncCommandsIn(process.env.DISCORD_GUILD_ID)
+        .then(() => creator.syncCommandPermissions());
+} else {
+    creator.syncCommands()
+        .then(() => creator.syncCommandPermissions());
+}
+    
 
 client.login(process.env.DISCORD_CLIENT_TOKEN);
 


### PR DESCRIPTION
As mentioned [here]( #52 ). The majority of discord bots require roles access management.
This is already possible for slash-commands. And [slash-create](https://www.npmjs.com/package/slash-create) already [supports ](https://slash-create.js.org/#/docs/main/latest/examples/command) it.

For now only [defaultPermission](https://slash-create.js.org/#/docs/main/latest/typedef/SlashCommandOptions) property works fine. Defining permissions in `permissions` object would not work as syncing permissions requires one extra step after commands sync.

This PR fixes these issues. Now you would be able to use `permissions` object to restrict or allow access for specific roles or users.
![image](https://user-images.githubusercontent.com/20926428/134781961-81a6bf79-b485-4b07-9831-02ba409673e8.png)

